### PR TITLE
Set a secret token to keep login sessions around

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -8,6 +8,7 @@ class Spotifyifyly < Sinatra::Base
   enable :sessions
 
   set :logging, true
+  set :session_secret, "my_secret_key_thats_really_secret_i_*swear*"
 
   def current_user
     # If you're logged in, return logged in User


### PR DESCRIPTION
Sessions are signed with a secret token that gets randomly re-generated every time the app starts, which invalidates logins each time you restart the server. This adds a fixed, known secret token, so that logins will continue to work.
